### PR TITLE
Enabled strict mode in tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "clean": "rm -rf dist docs && mkdir -p dist docs",
-    "generate-docs": "typedoc --out docs minimal --mode \"file\"",
+    "generate-docs": "typedoc --out docs --theme minimal --mode \"file\"",
     "generate-docs-ci": "typedoc --out docs --theme ../typedoc-canvo-theme/bin/default --mode \"file\"",
     "test": "mocha",
     "transpile": "tsc",

--- a/src/GifProvider.ts
+++ b/src/GifProvider.ts
@@ -5,11 +5,11 @@ export interface GifProvider {
     /**
      * @param limit - The maximum number of results to return
      */
-    trending: { (limit: Number): Promise<Gif[]> },
+    trending: { (limit: number): Promise<Gif[]> },
 
     /**
      * @param query - The search query
      * @param limit - The maximum number of results to return
      */
-    search: { (query: string, limit: Number) : Promise<Gif[]> }
+    search: { (query: string, limit: number) : Promise<Gif[]> }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,10 @@
     "esModuleInterop": true,
     "strict": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,7 @@
     "target": "es6",
     "lib": ["es2017", "es7", "es6"],
     "alwaysStrict": true,
-    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
@@ -15,10 +13,6 @@
     "esModuleInterop": true,
     "strict": true
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "declarationMap": true,
     "outDir": "dist",
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
   "include": [
     "src"


### PR DESCRIPTION
### Fixes #9.

### Changes

* Enabled strict mode in `tsconfig.json`.
* Updated interface in `src/GifProvider.ts` to use primitive types.
* Updated `yarn generate-docs` script to properly use the `minimal` theme available in `TypeDoc`.