### PR TITLE
add starting point for GitHub Actions

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: npm install
+        run: npm install
+      - name: transpile
+        run: npm run transpile
+      - name: run tests
+        run: npm test
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+          if-no-files-found: error
+
+  publish-npm:
+    name: Publish to NPMjs
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: ./dist
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+          registry-url: "https://registry.npmjs.org"
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: npm install
+        run: npm install
+      - name: transpile
+        run: npm run transpile
+      - name: run tests
+        run: npm test


### PR DESCRIPTION
This PR adds a starting point GitHub Actions for the projects. #6 


`pr.yaml` will run for Pull Requests and perform the following actions

1. NPM Install
1. Transpile the Typescript
1. Run Unit Tests

`master.yaml` will run on pushes to the Main branch. 

- build
  1. NPM Install
  1. Transpile the Typescript
  1. Run Unit Tests
  1. Upload dist as an artifact
- publish to npm
  1. Publish to NPM using Repo Secret `NPM_TOKEN`

