### PR TITLE
Update license to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "email": "hello@jamesyoung.ch",
     "url": "jamesyoung.ch"
   },
-  "license": "ISC",
+  "license": "MIT",
   "repository": {
     "url": "https://github.com/jamescallumyoung/gif-provider.git",
     "type": "git"


### PR DESCRIPTION
Update the license field in `package.json` to MIT, to match the LICENSE file.